### PR TITLE
PANDARIA: add calico 3.17.2

### DIFF
--- a/images-list
+++ b/images-list
@@ -3,15 +3,16 @@
 # https://github.com/rancher/image-mirror/pull/27
 #
 # LIST FORMAT: <SOURCE> <DESTINATION> <TAG>
-calico/cni cnrancher/mirrored-calico-cni v3.17.6
 calico/cni cnrancher/mirrored-calico-cni v3.22.4
 calico/cni cnrancher/mirrored-calico-cni v3.22.5
-calico/kube-controllers cnrancher/mirrored-calico-kube-controllers v3.17.6
+calico/ctl cnrancher/mirrored-calico-ctl v3.17.2
 calico/kube-controllers cnrancher/mirrored-calico-kube-controllers v3.22.4
 calico/kube-controllers cnrancher/mirrored-calico-kube-controllers v3.22.5
+calico/node cnrancher/mirrored-calico-node v3.17.2
 calico/node cnrancher/mirrored-calico-node v3.17.6
 calico/node cnrancher/mirrored-calico-node v3.22.4
 calico/node cnrancher/mirrored-calico-node v3.22.5
+calico/pod2daemon-flexvol cnrancher/mirrored-calico-pod2daemon-flexvol v3.17.2
 calico/pod2daemon-flexvol cnrancher/mirrored-calico-pod2daemon-flexvol v3.17.6
 calico/pod2daemon-flexvol cnrancher/mirrored-calico-pod2daemon-flexvol v3.22.4
 calico/pod2daemon-flexvol cnrancher/mirrored-calico-pod2daemon-flexvol v3.22.5


### PR DESCRIPTION
添加 calico 相关镜像 ~3.16.5（v1.19.16-rancher2-1使用）~，3.17.2（v1.20.15-rancher2-1使用）

目前查看 cnrancher 已有 mirror 的 calico 3.17.6 镜像没有 arm64 的
<img width="1329" alt="截屏2022-12-06 16 01 11" src="https://user-images.githubusercontent.com/51182588/205856157-6e2231e1-d4db-4404-aab2-53d5bb78810e.png">

calico 镜像源 3.17.6 的有 arm64，3.17.6-arm64 的 ARCH 是 amd（怀疑 calico 官方镜像较早的版本打包有问题，3.22 的没问题）

<img width="1303" alt="截屏2022-12-06 16 07 49" src="https://user-images.githubusercontent.com/51182588/205856336-eef627ec-6cc4-4ad8-b044-fd2471f5baaa.png">

image-mirror.sh 不好处理这个情况，如果确实有该问题可能手动打下会好点