### PR TITLE
PANDARIA: mirror thanos v0.30.1

### DIFF
--- a/images-list
+++ b/images-list
@@ -28,3 +28,4 @@ quay.io/jetstack/cert-manager-controller cnrancher/mirrored-jetstack-cert-manage
 quay.io/jetstack/cert-manager-ctl cnrancher/mirrored-jetstack-cert-manager-ctl v1.10.1
 quay.io/jetstack/cert-manager-webhook cnrancher/mirrored-jetstack-cert-manager-webhook v1.10.1
 quay.io/thanos/thanos cnrancher/mirrored-thanos-thanos v0.27.0
+quay.io/thanos/thanos cnrancher/mirrored-thanos-thanos v0.30.1


### PR DESCRIPTION
thanos 需要做升级解决 cve 问题，最新 v0.30.1 版本只有 MEDIUM、LOW 级别的 cve

**Relate issue**
https://github.com/cnrancher/pandaria-images-scanning/issues/78
https://github.com/cnrancher/pandaria-images-scanning/issues/66