### PR TITLE
PANDARIA: Mirror nvidia/k8s/dcgm-exporter 3.1.6-3.1.3-ubuntu20.04 image

### DIFF
--- a/images-list
+++ b/images-list
@@ -23,6 +23,7 @@ ghcr.io/k8snetworkplumbingwg/multus-cni cnrancher/mirrored-multus-cni v3.9.3
 jimmidyson/configmap-reload cnrancher/jimmidyson-configmap-reload v0.7.1
 mysql cnrancher/mirrored-mysql 8.0.31
 nfvpe/multus cnrancher/mirrored-nfvpe-multus v3.4.2
+nvcr.io/nvidia/k8s/dcgm-exporter cnrancher/mirrored-nvidia-dcgm-exporter 3.1.6-3.1.3-ubuntu20.04
 quay.io/jetstack/cert-manager-cainjector cnrancher/mirrored-jetstack-cert-manager-cainjector v1.10.1
 quay.io/jetstack/cert-manager-cainjector cnrancher/mirrored-jetstack-cert-manager-cainjector v1.10.2
 quay.io/jetstack/cert-manager-controller cnrancher/mirrored-jetstack-cert-manager-controller v1.10.1


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

New image

#### Linked Issues ####

https://github.com/cnrancher/pandaria-catalog/pull/136
https://github.com/cnrancher/pandaria/issues/2742

#### Additional Notes ####

#### Final Checks after the PR is merged ####
- [x] Confirm that you can pull the new images and tags from DockerHub