### PR TITLE
PANDARIA: mirror nginx 1.23.3 and grafana:9.4.3

### DIFF
--- a/images-list
+++ b/images-list
@@ -20,9 +20,11 @@ fluent/fluent-bit cnrancher/mirrored-fluent-fluent-bit 1.8.13
 ghcr.io/k8snetworkplumbingwg/multus-cni cnrancher/mirrored-multus-cni v3.7.1
 ghcr.io/k8snetworkplumbingwg/multus-cni cnrancher/mirrored-multus-cni v3.9.2
 ghcr.io/k8snetworkplumbingwg/multus-cni cnrancher/mirrored-multus-cni v3.9.3
+grafana/grafana cnrancher/mirrored-grafana-grafana 9.4.3
 jimmidyson/configmap-reload cnrancher/jimmidyson-configmap-reload v0.7.1
 mysql cnrancher/mirrored-mysql 8.0.31
 nfvpe/multus cnrancher/mirrored-nfvpe-multus v3.4.2
+nginx cnrancher/mirrored-nginx 1.23.3
 nvcr.io/nvidia/k8s/dcgm-exporter cnrancher/mirrored-nvidia-dcgm-exporter 3.1.6-3.1.3-ubuntu20.04
 quay.io/jetstack/cert-manager-cainjector cnrancher/mirrored-jetstack-cert-manager-cainjector v1.10.1
 quay.io/jetstack/cert-manager-cainjector cnrancher/mirrored-jetstack-cert-manager-cainjector v1.10.2


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
New image

#### Linked Issues ####
https://github.com/cnrancher/pandaria-images-scanning/issues/68

#### Additional Notes ####

最近发布的 nginx 1.23.3 没有 HIGH,CRITICAL 级别 cve，社区版的 mirror list 还没同步
```
trivy image --no-progress --ignore-unfixed --severity HIGH,CRITICAL --security-checks vuln --exit-code 1 library/nginx:1.23.3
2023-03-16T17:16:11.391+0800	INFO	Vulnerability scanning is enabled
2023-03-16T17:16:17.334+0800	INFO	Detected OS: debian
2023-03-16T17:16:17.334+0800	INFO	Detecting Debian vulnerabilities...
2023-03-16T17:16:17.395+0800	INFO	Number of language-specific files: 0

library/nginx:1.23.3 (debian 11.6)

Total: 0 (HIGH: 0, CRITICAL: 0)
```

最新 grafana 9.4.3 只有一个 HIGH 级别 cve
```
trivy image --no-progress --ignore-unfixed --severity HIGH,CRITICAL --security-checks vuln --exit-code 1 grafana/grafana:9.4.3
2023-03-16T17:50:37.087+0800	INFO	Vulnerability scanning is enabled
2023-03-16T17:50:45.390+0800	INFO	Detected OS: alpine
2023-03-16T17:50:45.390+0800	INFO	Detecting Alpine vulnerabilities...
2023-03-16T17:50:45.392+0800	INFO	Number of language-specific files: 1
2023-03-16T17:50:45.392+0800	INFO	Detecting gobinary vulnerabilities...

grafana/grafana:9.4.3 (alpine 3.15.7)

Total: 0 (HIGH: 0, CRITICAL: 0)


usr/share/grafana/bin/grafana (gobinary)

Total: 1 (HIGH: 1, CRITICAL: 0)

┌──────────────────┬────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│     Library      │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                            Title                            │
├──────────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ golang.org/x/net │ CVE-2022-41723 │ HIGH     │ v0.4.0            │ 0.7.0         │ golang.org/x/net/http2: avoid quadratic complexity in HPACK │
│                  │                │          │                   │               │ decoding                                                    │
│                  │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-41723                  │
└──────────────────┴────────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
```

#### Final Checks after the PR is merged ####
- [x] Confirm that you can pull the new images and tags from DockerHub